### PR TITLE
Convert to RFC2873 style assembly for x86_64 and aarch64

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,2 +1,3 @@
 # Contributors
 * Anti Revoluzzer <anti@rvlzzr.com>
+* Anselm Busse <anselm.busse@outlook.com>

--- a/src/aarch64-linux.rs
+++ b/src/aarch64-linux.rs
@@ -56,11 +56,9 @@ pub unsafe fn syscall_nr(x8: usize, a: &[usize]) -> ! {
 pub unsafe fn syscall_0(x8: usize) -> Result<usize, usize> {
     let x0: usize;
     asm!(
-        "svc $$0"
-        : "={x0}"(x0)
-        : "{x8}"(x8)
-        : "cc", "memory"
-        : "volatile"
+        "svc #0",
+        in("x8") x8,
+        out("x0") x0
     );
     if x0 < 0xffff_ffff_ffff_f000 {
         Ok(x0)
@@ -78,13 +76,10 @@ pub unsafe fn syscall_0(x8: usize) -> Result<usize, usize> {
 #[inline(always)]
 pub unsafe fn syscall_0_nr(x8: usize) -> ! {
     asm!(
-        "svc $$0"
-        :
-        : "{x8}"(x8)
-        : "cc"
-        : "volatile"
+        "svc #0",
+        in("x8") x8,
+        options(noreturn)
     );
-    unreachable_unchecked()
 }
 
 /// Performs a system call with one argument and returns the result.
@@ -95,11 +90,10 @@ pub unsafe fn syscall_0_nr(x8: usize) -> ! {
 #[inline(always)]
 pub unsafe fn syscall_1(x8: usize, mut x0: usize) -> Result<usize, usize> {
     asm!(
-        "svc $$0"
-        : "+{x0}"(x0)
-        : "{x8}"(x8)
-        : "cc", "memory"
-        : "volatile"
+        "svc #0",
+        in("x8") x8,
+        in("x0") x0,
+        lateout("x0") x0
     );
     if x0 < 0xffff_ffff_ffff_f000 {
         Ok(x0)
@@ -118,13 +112,11 @@ pub unsafe fn syscall_1(x8: usize, mut x0: usize) -> Result<usize, usize> {
 #[inline(always)]
 pub unsafe fn syscall_1_nr(x8: usize, x0: usize) -> ! {
     asm!(
-        "svc $$0"
-        :
-        : "{x8}"(x8), "{x0}"(x0)
-        : "cc"
-        : "volatile"
+        "svc #0",
+        in("x8") x8,
+        in("x0") x0,
+        options(noreturn)
     );
-    unreachable_unchecked()
 }
 
 /// Performs a system call with two arguments and returns the result.
@@ -135,11 +127,11 @@ pub unsafe fn syscall_1_nr(x8: usize, x0: usize) -> ! {
 #[inline(always)]
 pub unsafe fn syscall_2(x8: usize, mut x0: usize, x1: usize) -> Result<usize, usize> {
     asm!(
-        "svc $$0"
-        : "+{x0}"(x0)
-        : "{x8}"(x8), "{x1}"(x1)
-        : "cc", "memory"
-        : "volatile"
+        "svc #0",
+        in("x8") x8,
+        in("x0") x0,
+        in("x1") x1,
+        lateout("x0") x0
     );
     if x0 < 0xffff_ffff_ffff_f000 {
         Ok(x0)
@@ -158,13 +150,12 @@ pub unsafe fn syscall_2(x8: usize, mut x0: usize, x1: usize) -> Result<usize, us
 #[inline(always)]
 pub unsafe fn syscall_2_nr(x8: usize, x0: usize, x1: usize) -> ! {
     asm!(
-        "svc $$0"
-        :
-        : "{x8}"(x8), "{x0}"(x0), "{x1}"(x1)
-        : "cc"
-        : "volatile"
+        "svc #0",
+        in("x8") x8,
+        in("x0") x0,
+        in("x1") x1,
+        options(noreturn)
     );
-    unreachable_unchecked()
 }
 
 /// Performs a system call with three arguments and returns the result.
@@ -175,11 +166,12 @@ pub unsafe fn syscall_2_nr(x8: usize, x0: usize, x1: usize) -> ! {
 #[inline(always)]
 pub unsafe fn syscall_3(x8: usize, mut x0: usize, x1: usize, x2: usize) -> Result<usize, usize> {
     asm!(
-        "svc $$0"
-        : "+{x0}"(x0)
-        : "{x8}"(x8), "{x1}"(x1), "{x2}"(x2)
-        : "cc", "memory"
-        : "volatile"
+        "svc #0",
+        in("x8") x8,
+        in("x0") x0,
+        in("x1") x1,
+        in("x2") x2,
+        lateout("x0") x0
     );
     if x0 < 0xffff_ffff_ffff_f000 {
         Ok(x0)
@@ -198,13 +190,13 @@ pub unsafe fn syscall_3(x8: usize, mut x0: usize, x1: usize, x2: usize) -> Resul
 #[inline(always)]
 pub unsafe fn syscall_3_nr(x8: usize, x0: usize, x1: usize, x2: usize) -> ! {
     asm!(
-        "svc $$0"
-        :
-        : "{x8}"(x8), "{x0}"(x0), "{x1}"(x1), "{x2}"(x2)
-        : "cc"
-        : "volatile"
+        "svc #0",
+        in("x8") x8,
+        in("x0") x0,
+        in("x1") x1,
+        in("x2") x2,
+        options(noreturn)
     );
-    unreachable_unchecked()
 }
 
 /// Performs a system call with four arguments and returns the result.
@@ -215,11 +207,13 @@ pub unsafe fn syscall_3_nr(x8: usize, x0: usize, x1: usize, x2: usize) -> ! {
 #[inline(always)]
 pub unsafe fn syscall_4(x8: usize, mut x0: usize, x1: usize, x2: usize, x3: usize) -> Result<usize, usize> {
     asm!(
-        "svc $$0"
-        : "+{x0}"(x0)
-        : "{x8}"(x8), "{x1}"(x1), "{x2}"(x2), "{x3}"(x3)
-        : "cc", "memory"
-        : "volatile"
+        "svc #0",
+        in("x8") x8,
+        in("x0") x0,
+        in("x1") x1,
+        in("x2") x2,
+        in("x3") x3,
+        lateout("x0") x0
     );
     if x0 < 0xffff_ffff_ffff_f000 {
         Ok(x0)
@@ -238,13 +232,14 @@ pub unsafe fn syscall_4(x8: usize, mut x0: usize, x1: usize, x2: usize, x3: usiz
 #[inline(always)]
 pub unsafe fn syscall_4_nr(x8: usize, x0: usize, x1: usize, x2: usize, x3: usize) -> ! {
     asm!(
-        "svc $$0"
-        :
-        : "{x8}"(x8), "{x0}"(x0), "{x1}"(x1), "{x2}"(x2), "{x3}"(x3)
-        : "cc"
-        : "volatile"
+        "svc #0",
+        in("x8") x8,
+        in("x0") x0,
+        in("x1") x1,
+        in("x2") x2,
+        in("x3") x3,
+        options(noreturn)
     );
-    unreachable_unchecked()
 }
 
 /// Performs a system call with five arguments and returns the result.
@@ -255,11 +250,14 @@ pub unsafe fn syscall_4_nr(x8: usize, x0: usize, x1: usize, x2: usize, x3: usize
 #[inline(always)]
 pub unsafe fn syscall_5(x8: usize, mut x0: usize, x1: usize, x2: usize, x3: usize, x4: usize) -> Result<usize, usize> {
     asm!(
-        "svc $$0"
-        : "+{x0}"(x0)
-        : "{x8}"(x8), "{x1}"(x1), "{x2}"(x2), "{x3}"(x3), "{x4}"(x4)
-        : "cc", "memory"
-        : "volatile"
+        "svc #0",
+        in("x8") x8,
+        in("x0") x0,
+        in("x1") x1,
+        in("x2") x2,
+        in("x3") x3,
+        in("x4") x4,
+        lateout("x0") x0
     );
     if x0 < 0xffff_ffff_ffff_f000 {
         Ok(x0)
@@ -278,13 +276,15 @@ pub unsafe fn syscall_5(x8: usize, mut x0: usize, x1: usize, x2: usize, x3: usiz
 #[inline(always)]
 pub unsafe fn syscall_5_nr(x8: usize, x0: usize, x1: usize, x2: usize, x3: usize, x4: usize) -> ! {
     asm!(
-        "svc $$0"
-        :
-        : "{x8}"(x8), "{x0}"(x0), "{x1}"(x1), "{x2}"(x2), "{x3}"(x3), "{x4}"(x4)
-        : "cc"
-        : "volatile"
+        "svc #0",
+        in("x8") x8,
+        in("x0") x0,
+        in("x1") x1,
+        in("x2") x2,
+        in("x3") x3,
+        in("x4") x4,
+        options(noreturn)
     );
-    unreachable_unchecked()
 }
 
 /// Performs a system call with six arguments and returns the result.
@@ -304,11 +304,15 @@ pub unsafe fn syscall_6(
 ) -> Result<usize, usize>
 {
     asm!(
-        "svc $$0"
-        : "+{x0}"(x0)
-        : "{x8}"(x8), "{x1}"(x1), "{x2}"(x2), "{x3}"(x3), "{x4}"(x4), "{x5}"(x5)
-        : "cc", "memory"
-        : "volatile"
+        "svc #0",
+        in("x8") x8,
+        in("x0") x0,
+        in("x1") x1,
+        in("x2") x2,
+        in("x3") x3,
+        in("x4") x4,
+        in("x5") x5,
+        lateout("x0") x0,
     );
     if x0 < 0xffff_ffff_ffff_f000 {
         Ok(x0)
@@ -327,11 +331,14 @@ pub unsafe fn syscall_6(
 #[inline(always)]
 pub unsafe fn syscall_6_nr(x8: usize, x0: usize, x1: usize, x2: usize, x3: usize, x4: usize, x5: usize) -> ! {
     asm!(
-        "svc $$0"
-        :
-        : "{x8}"(x8), "{x0}"(x0), "{x1}"(x1), "{x2}"(x2), "{x3}"(x3), "{x4}"(x4), "{x5}"(x5)
-        : "cc"
-        : "volatile"
+        "svc #0",
+        in("x8") x8,
+        in("x0") x0,
+        in("x1") x1,
+        in("x2") x2,
+        in("x3") x3,
+        in("x4") x4,
+        in("x5") x5,
+        options(noreturn)
     );
-    unreachable_unchecked()
 }

--- a/src/x86_64-linux.rs
+++ b/src/x86_64-linux.rs
@@ -55,11 +55,10 @@ pub unsafe fn syscall_nr(rax: usize, a: &[usize]) -> ! {
 #[inline(always)]
 pub unsafe fn syscall_0(mut rax: usize) -> Result<usize, usize> {
     asm!(
-        "syscall"
-        : "+{rax}"(rax)
-        :
-        : "rcx", "r11", "memory"
-        : "volatile"
+        "syscall",
+        inlateout("rax") rax => rax,
+        out("rcx") _,
+        out("r11") _
     );
     if rax < 0xffff_ffff_ffff_f000 {
         Ok(rax)
@@ -77,13 +76,10 @@ pub unsafe fn syscall_0(mut rax: usize) -> Result<usize, usize> {
 #[inline(always)]
 pub unsafe fn syscall_0_nr(rax: usize) -> ! {
     asm!(
-        "syscall"
-        :
-        : "{rax}"(rax)
-        : "rcx", "r11"
-        : "volatile"
+        "syscall",
+        in("rax") rax,
+        options(noreturn)
     );
-    unreachable_unchecked()
 }
 
 /// Performs a system call with one argument and returns the result.
@@ -94,11 +90,11 @@ pub unsafe fn syscall_0_nr(rax: usize) -> ! {
 #[inline(always)]
 pub unsafe fn syscall_1(mut rax: usize, rdi: usize) -> Result<usize, usize> {
     asm!(
-        "syscall"
-        : "+{rax}"(rax)
-        : "{rdi}"(rdi)
-        : "rcx", "r11", "memory"
-        : "volatile"
+        "syscall",
+        inlateout("rax") rax => rax,
+        in("rdi") rdi,
+        out("rcx") _,
+        out("r11") _
     );
     if rax < 0xffff_ffff_ffff_f000 {
         Ok(rax)
@@ -117,13 +113,11 @@ pub unsafe fn syscall_1(mut rax: usize, rdi: usize) -> Result<usize, usize> {
 #[inline(always)]
 pub unsafe fn syscall_1_nr(rax: usize, rdi: usize) -> ! {
     asm!(
-        "syscall"
-        :
-        : "{rax}"(rax), "{rdi}"(rdi)
-        : "rcx", "r11"
-        : "volatile"
+        "syscall",
+        in("rax") rax,
+        in("rdi") rdi,
+        options(noreturn)
     );
-    unreachable_unchecked()
 }
 
 /// Performs a system call with two arguments and returns the result.
@@ -134,11 +128,12 @@ pub unsafe fn syscall_1_nr(rax: usize, rdi: usize) -> ! {
 #[inline(always)]
 pub unsafe fn syscall_2(mut rax: usize, rdi: usize, rsi: usize) -> Result<usize, usize> {
     asm!(
-        "syscall"
-        : "+{rax}"(rax)
-        : "{rdi}"(rdi), "{rsi}"(rsi)
-        : "rcx", "r11", "memory"
-        : "volatile"
+        "syscall",
+        inlateout("rax") rax => rax,
+        in("rdi") rdi,
+        in("rsi") rsi,
+        out("rcx") _,
+        out("r11") _
     );
     if rax < 0xffff_ffff_ffff_f000 {
         Ok(rax)
@@ -157,13 +152,12 @@ pub unsafe fn syscall_2(mut rax: usize, rdi: usize, rsi: usize) -> Result<usize,
 #[inline(always)]
 pub unsafe fn syscall_2_nr(rax: usize, rdi: usize, rsi: usize) -> ! {
     asm!(
-        "syscall"
-        :
-        : "{rax}"(rax), "{rdi}"(rdi), "{rsi}"(rsi)
-        : "rcx", "r11"
-        : "volatile"
+        "syscall",
+        in("rax") rax,
+        in("rdi") rdi,
+        in("rsi") rsi,
+        options(noreturn)
     );
-    unreachable_unchecked()
 }
 
 /// Performs a system call with three arguments and returns the result.
@@ -174,11 +168,13 @@ pub unsafe fn syscall_2_nr(rax: usize, rdi: usize, rsi: usize) -> ! {
 #[inline(always)]
 pub unsafe fn syscall_3(mut rax: usize, rdi: usize, rsi: usize, rdx: usize) -> Result<usize, usize> {
     asm!(
-        "syscall"
-        : "+{rax}"(rax)
-        : "{rdi}"(rdi), "{rsi}"(rsi), "{rdx}"(rdx)
-        : "rcx", "r11", "memory"
-        : "volatile"
+        "syscall",
+        inlateout("rax") rax => rax,
+        in("rdi") rdi,
+        in("rsi") rsi,
+        in("rdx") rdx,
+        out("rcx") _,
+        out("r11") _
     );
     if rax < 0xffff_ffff_ffff_f000 {
         Ok(rax)
@@ -197,13 +193,13 @@ pub unsafe fn syscall_3(mut rax: usize, rdi: usize, rsi: usize, rdx: usize) -> R
 #[inline(always)]
 pub unsafe fn syscall_3_nr(rax: usize, rdi: usize, rsi: usize, rdx: usize) -> ! {
     asm!(
-        "syscall"
-        :
-        : "{rax}"(rax), "{rdi}"(rdi), "{rsi}"(rsi), "{rdx}"(rdx)
-        : "rcx", "r11"
-        : "volatile"
+        "syscall",
+        in("rax") rax,
+        in("rdi") rdi,
+        in("rsi") rsi,
+        in("rdx") rdx,
+        options(noreturn)
     );
-    unreachable_unchecked()
 }
 
 /// Performs a system call with four arguments and returns the result.
@@ -214,11 +210,14 @@ pub unsafe fn syscall_3_nr(rax: usize, rdi: usize, rsi: usize, rdx: usize) -> ! 
 #[inline(always)]
 pub unsafe fn syscall_4(mut rax: usize, rdi: usize, rsi: usize, rdx: usize, r10: usize) -> Result<usize, usize> {
     asm!(
-        "syscall"
-        : "+{rax}"(rax)
-        : "{rdi}"(rdi), "{rsi}"(rsi), "{rdx}"(rdx), "{r10}"(r10)
-        : "rcx", "r11", "memory"
-        : "volatile"
+        "syscall",
+        inlateout("rax") rax => rax,
+        in("rdi") rdi,
+        in("rsi") rsi,
+        in("rdx") rdx,
+        in("r10") r10,
+        out("rcx") _,
+        out("r11") _
     );
     if rax < 0xffff_ffff_ffff_f000 {
         Ok(rax)
@@ -237,13 +236,14 @@ pub unsafe fn syscall_4(mut rax: usize, rdi: usize, rsi: usize, rdx: usize, r10:
 #[inline(always)]
 pub unsafe fn syscall_4_nr(rax: usize, rdi: usize, rsi: usize, rdx: usize, r10: usize) -> ! {
     asm!(
-        "syscall"
-        :
-        : "{rax}"(rax), "{rdi}"(rdi), "{rsi}"(rsi), "{rdx}"(rdx), "{r10}"(r10)
-        : "rcx", "r11"
-        : "volatile"
+        "syscall",
+        in("rax") rax,
+        in("rdi") rdi,
+        in("rsi") rsi,
+        in("rdx") rdx,
+        in("r10") r10,
+        options(noreturn)
     );
-    unreachable_unchecked()
 }
 
 /// Performs a system call with five arguments and returns the result.
@@ -262,11 +262,15 @@ pub unsafe fn syscall_5(
 ) -> Result<usize, usize>
 {
     asm!(
-        "syscall"
-        : "+{rax}"(rax)
-        : "{rdi}"(rdi), "{rsi}"(rsi), "{rdx}"(rdx), "{r10}"(r10), "{r8}"(r8)
-        : "rcx", "r11", "memory"
-        : "volatile"
+        "syscall",
+        inlateout("rax") rax => rax,
+        in("rdi") rdi,
+        in("rsi") rsi,
+        in("rdx") rdx,
+        in("r10") r10,
+        in("r8") r8,
+        out("rcx") _,
+        out("r11") _
     );
     if rax < 0xffff_ffff_ffff_f000 {
         Ok(rax)
@@ -285,13 +289,15 @@ pub unsafe fn syscall_5(
 #[inline(always)]
 pub unsafe fn syscall_5_nr(rax: usize, rdi: usize, rsi: usize, rdx: usize, r10: usize, r8: usize) -> ! {
     asm!(
-        "syscall"
-        :
-        : "{rax}"(rax), "{rdi}"(rdi), "{rsi}"(rsi), "{rdx}"(rdx), "{r10}"(r10), "{r8}"(r8)
-        : "rcx", "r11"
-        : "volatile"
+        "syscall",
+        in("rax") rax,
+        in("rdi") rdi,
+        in("rsi") rsi,
+        in("rdx") rdx,
+        in("r10") r10,
+        in("r8") r8,
+        options(noreturn)
     );
-    unreachable_unchecked()
 }
 
 /// Performs a system call with six arguments and returns the result.
@@ -311,11 +317,16 @@ pub unsafe fn syscall_6(
 ) -> Result<usize, usize>
 {
     asm!(
-        "syscall"
-        : "+{rax}"(rax)
-        : "{rdi}"(rdi), "{rsi}"(rsi), "{rdx}"(rdx), "{r10}"(r10), "{r8}"(r8), "{r9}"(r9)
-        : "rcx", "r11", "memory"
-        : "volatile"
+        "syscall",
+        inlateout("rax") rax => rax,
+        in("rdi") rdi,
+        in("rsi") rsi,
+        in("rdx") rdx,
+        in("r10") r10,
+        in("r8") r8,
+        in("r9") r9,
+        out("rcx") _,
+        out("r11") _
     );
     if rax < 0xffff_ffff_ffff_f000 {
         Ok(rax)
@@ -334,11 +345,14 @@ pub unsafe fn syscall_6(
 #[inline(always)]
 pub unsafe fn syscall_6_nr(rax: usize, rdi: usize, rsi: usize, rdx: usize, r10: usize, r8: usize, r9: usize) -> ! {
     asm!(
-        "syscall"
-        :
-        : "{rax}"(rax), "{rdi}"(rdi), "{rsi}"(rsi), "{rdx}"(rdx), "{r10}"(r10), "{r8}"(r8), "{r9}"(r9)
-        : "rcx", "r11"
-        : "volatile"
+        "syscall",
+        in("rax") rax,
+        in("rdi") rdi,
+        in("rsi") rsi,
+        in("rdx") rdx,
+        in("r10") r10,
+        in("r8") r8,
+        in("r9") r9,
+        options(noreturn)
     );
-    unreachable_unchecked()
 }


### PR DESCRIPTION
This patch addresses the compiler errors reported in Issue #2 partially by converting the existing inline assembly to RFC2873 conforming assembly for `x86_64` and `aarch64` Linux syscalls.